### PR TITLE
Fix - undefined error when `imgData` and `imgArr` are both empty

### DIFF
--- a/packages/vue-dark-photo/components/windows.vue
+++ b/packages/vue-dark-photo/components/windows.vue
@@ -2,7 +2,7 @@
   <transition name="fade">
     <div v-show="visible">
       <div id="bg" ref="bg" class="bg" @click="close"></div>
-      <div ref="windows" class="windows">
+      <div ref="windows" class="windows" :style="`width: ${imageWidthPercent}%`">
         <div class="windows_header">
           <slot name="title" class="title">
             <span>{{ title }}</span>
@@ -33,6 +33,10 @@ export default {
       type: String,
       default: ''
     },
+    imageWidthPercent: {
+      type: Number,
+      default: 50
+    }
   },
   methods: {
     close() {

--- a/packages/vue-dark-photo/index.vue
+++ b/packages/vue-dark-photo/index.vue
@@ -321,7 +321,7 @@ export default {
   },
   computed: {
     currentImg() {
-      return this.imgData ? this.imgData : this.imgArr[this.index];
+      return this.imgData ? this.imgData : this.imgArr.length > this.index ? this.imgArr[this.index] : '';
     },
     currentLength() {
       return this.imgData


### PR DESCRIPTION
- 组件初始传入`imgData`为空字符串时，由于`imgArr`也为空，`currentImg()`返回`undefined`，导致`this.currentImg.lastIndexOf("?")` 报错 ```Error in render: "TypeError: Cannot read properties of undefined (reading 'lastIndexOf')"```。

- 图片预览windows初始值宽度为`50%`，且值无法参数调节，如想调整预览图片初始大小需要重写CSS实现。